### PR TITLE
verbose fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,26 @@ python:
 before_install:
   - python3 -m pip install --upgrade pip setuptools wheel
 install:
-  - pip3 install git+https://github.com/nextstrain/cli
+  # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html#the-travis-yml-file
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  # Install nextstrain cli
+  - conda install -n base -c conda-forge mamba --yes
+  - conda activate base
+  - mamba create -n nextstrain -c bioconda nextstrain-cli --yes
+  - conda activate nextstrain
+  - mamba install -c conda-forge -c bioconda augur auspice nextalign snakemake git --yes
+#  - pip3 install git+https://github.com/nextstrain/cli
   - nextstrain version
   - nextstrain check-setup
   - nextstrain update


### PR DESCRIPTION
### Description of proposed changes

Switching from `pip3 install` to `mamba install` fixed this [travis ci error](https://app.travis-ci.com/github/nextstrain/zika/builds/247796868#L242). 

The `pip3 install` was nice as a very concise one-liner. The `mamba install` is more consistent with our [nextstrain install docs](https://docs.nextstrain.org/en/latest/install.html#installation-steps). Feel free to suggest a cleaner fix. Another alternative solution is to set up CI using github actions. 

### Testing

See [alt_travis travis.ci passing build](https://github.com/nextstrain/zika/runs/5520264628). 
