### PR TITLE
CI: Use a centralized pathogen repo CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,23 +5,5 @@ on:
   - pull_request
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
-        with:
-          python-version: "3.7"
-
-      - run: python3 -m pip install --upgrade pip setuptools wheel
-      - run: python3 -m pip install nextstrain-cli
-      - run: nextstrain version
-      - run: nextstrain check-setup
-      - run: nextstrain update
-
-      - name: Copy example data
-        run: |
-          mkdir -p data/
-          cp -v example_data/* data/
-
-      - run: nextstrain build --docker .
+  ci:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master


### PR DESCRIPTION
git ref of the branch should be updated to "master" before merge.

Related to #16.
