### PR TITLE
Specify `--cores all` for `nextstrain build .`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are two main ways to run & visualise the output from this build:
 The first, and easiest, way to run this pathogen build is using the [Nextstrain
 command-line tool][nextstrain-cli]:
 ```
-nextstrain build .
+nextstrain build . --cores all
 nextstrain view auspice/
 ```
 


### PR DESCRIPTION
The existing command only works for snakemake<5.11.0, which is not a requirement for this workflow.

More info: https://github.com/snakemake/snakemake/issues/283