### PR TITLE
zstd

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -16,11 +16,11 @@ files = rules.files.params
 rule download:
     message: "Downloading sequences and metadata from data.nextstrain.org"
     output:
-        sequences = "data/sequences.fasta.xz",
-        metadata = "data/metadata.tsv.gz"
+        sequences = "data/sequences.fasta.zst",
+        metadata = "data/metadata.tsv.zst"
     params:
-        sequences_url = "https://data.nextstrain.org/files/zika/sequences.fasta.xz",
-        metadata_url = "https://data.nextstrain.org/files/zika/metadata.tsv.gz"
+        sequences_url = "https://data.nextstrain.org/files/zika/sequences.fasta.zst",
+        metadata_url = "https://data.nextstrain.org/files/zika/metadata.tsv.zst"
     shell:
         """
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}
@@ -30,15 +30,15 @@ rule download:
 rule decompress:
     message: "Decompressing sequences and metadata"
     input:
-        sequences = "data/sequences.fasta.xz",
-        metadata = "data/metadata.tsv.gz"
+        sequences = "data/sequences.fasta.zst",
+        metadata = "data/metadata.tsv.zst"
     output:
         sequences = "data/sequences.fasta",
         metadata = "data/metadata.tsv"
     shell:
         """
-        gzip --decompress --keep {input.metadata}
-        xz --decompress --keep {input.sequences}
+        zstd -d -c {input.sequences} > {output.sequences}
+        zstd -d -c {input.metadata} > {output.metadata}
         """
 
 rule filter:


### PR DESCRIPTION
### Description of proposed changes

Use zstd compression instead of xz and gzip to be consistent with:

* nextstrain/ncov-ingest#345

### Related issue(s)

Related to:

* https://github.com/nextstrain/ncov-ingest/pull/345

Related PRs:

* https://github.com/nextstrain/fauna/pull/127
* https://github.com/nextstrain/dengue/pull/5
* https://github.com/nextstrain/measles/pull/7


### Testing

- [x] Checks pass
- [x] full run on AWS passes

Assuming the reviewer has the proper keys, could run manually via:

```
git clone https://github.com/nextstrain/zika.git
cd zika
git checkout zstd
nextstrain build .
nextstrain view auspice
```

The final build should look similar to:

* https://nextstrain.org/zika

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
