### PR TITLE
Move accession to the first column of metadata_all.tsv

### DIFF
--- a/phylogenetic/rules/merge_sequences_usvi.smk
+++ b/phylogenetic/rules/merge_sequences_usvi.smk
@@ -22,7 +22,13 @@ This part of the workflow usually includes the following steps:
 """
 
 rule append_usvi:
-    """Appending USVI sequences"""
+    """Appending USVI sequences
+
+    Notable columns:
+    - accession: Either the GenBank accession or USVI accession.
+    - genbank_accession: GenBank accession for Auspice to generate a URL to the NCBI GenBank record. Empty for USVI sequences.
+    - url: URL used in Auspice, to either link to the USVI github repo (https://github.com/blab/zika-usvi/) or link to the NCBI GenBank record ('https://www.ncbi.nlm.nih.gov/nuccore/*')
+    """
     input:
         sequences = "data/sequences.fasta",
         metadata = "data/metadata.tsv",

--- a/phylogenetic/rules/merge_sequences_usvi.smk
+++ b/phylogenetic/rules/merge_sequences_usvi.smk
@@ -43,5 +43,6 @@ rule append_usvi:
           -n accession \
           -e '$genbank_accession' \
         | csvtk concat -tl - {input.usvi_metadata} \
+        | tsv-select -H -f accession --rest last \
         > {output.metadata}
         """


### PR DESCRIPTION


## Description of proposed changes

During the merge of Usvi data and GenBank data, the `accession` field ended up as the last column. This caused confusion as the first column was named `genbank_accession` which could be mistaken for the strain ID.

This commit moves the `accession` column to the first column such that `accession` and `genbank_accession` are next to each other; hopefully, providing clarity that `accession` is being used as the strain ID, while `genbank_accession` can be used to generate a URL (in auspice) to the NCBI GenBank record if provided.

## Related issue(s)

## Checklist

- [ ] Checks pass

