### PR TITLE
fix: phylo: clean rule removes the USVI data

### DIFF
--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -19,7 +19,10 @@ if "custom_rules" in config:
 rule clean:
     """Removing directories: {params}"""
     params:
-        "data ",
+        "data/metadata.tsv* ",
+        "data/sequences.fasta* ",
+        "data/metadata_all.tsv ",
+        "data/sequences_all.fasta ",
         "results ",
         "auspice"
     shell:


### PR DESCRIPTION
## Description of proposed changes

Update the `clean` rule such that it does not remove USVI data.

## Related issue(s)

* https://github.com/nextstrain/zika/issues/37

## Checklist

- [ ] Checks pass

