### PR TITLE
ingest: Fix field_map config

### DIFF
--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -57,7 +57,7 @@ curate:
     update-date: update_date
     sra-accs: sra_accessions
     submitter-names: authors
-    submitter-affiliations: institution
+    submitter-affiliation: institution
   # Standardized strain name regex
   # Currently accepts any characters because we do not have a clear standard for strain names across pathogens
   strain_regex: '^.+$'


### PR DESCRIPTION
I noticed that the `institution` column was empty in the results/metadata.tsv when I was running through the workflow for the ingest tutorial.