### PR TITLE
ingest: support `custom_rules` from config

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -71,3 +71,9 @@ if send_slack_notifications:
 if config.get("trigger_rebuild", False):
 
     include: "rules/trigger_rebuild.smk"
+
+
+if "custom_rules" in config:
+    for rule_file in config["custom_rules"]:
+
+        include: rule_file


### PR DESCRIPTION
## Description of proposed changes

Follows the pathogen-repo-guide to allow users to define custom rules in the config to extend or override the core ingest workflow.

This is needed to support the upcoming ingest tutorials which use this repo as the example.

## Related issue(s)

Pre-work for https://github.com/nextstrain/zika/issues/44

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
