### PR TITLE
Update docs to use "defaults" and "build-configs" dirs

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -31,7 +31,7 @@ This will produce two files (within the `ingest` directory):
 Run the complete ingest pipeline and upload results to AWS S3 with
 
 ```sh
-nextstrain build . --configfiles config/config.yaml config/optional.yaml
+nextstrain build . --configfiles defaults/config.yaml defaults/optional.yaml
 ```
 
 ### Adding new sequences not from GenBank
@@ -57,12 +57,12 @@ Do the following to include sequences from static FASTA files.
     !ingest/data/{file-name}.ndjson
     ```
 
-3. Add the `file-name` (without the `.ndjson` extension) as a source to `ingest/config/config.yaml`. This will tell the ingest pipeline to concatenate the records to the GenBank sequences and run them through the same transform pipeline.
+3. Add the `file-name` (without the `.ndjson` extension) as a source to `ingest/defaults/config.yaml`. This will tell the ingest pipeline to concatenate the records to the GenBank sequences and run them through the same transform pipeline.
 
 ## Configuration
 
-Configuration takes place in `config/config.yaml` by default.
-Optional configs for uploading files and Slack notifications are in `config/optional.yaml`.
+Configuration takes place in `defaults/config.yaml` by default.
+Optional configs for uploading files and Slack notifications are in `defaults/optional.yaml`.
 
 ### Environment Variables
 

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -48,7 +48,7 @@ Alternatively, you can run the build using the
 example data provided in this repository.  To run the build by copying the
 example sequences into the `data/` directory, use the following:
 
-    nextstrain build .  --configfile profiles/ci/profiles_config.yaml
+    nextstrain build .  --configfile build-configs/ci/profiles_config.yaml
 
 [Nextstrain]: https://nextstrain.org
 [augur]: https://docs.nextstrain.org/projects/augur/en/stable/


### PR DESCRIPTION
## Description of proposed changes

Unintentionally missed in the migration to use "defaults" and "build-configs" directories. 

This updates the READMEs in the ingest and phylogenetic to reflect changes in a previous commit cd95122860c3420071a22d1102ff7eb3440610d1

## Related issue(s)

* https://github.com/nextstrain/zika/issues/45 (thanks for flagging!)

## Checklist

- [ ] Checks pass
