### PR TITLE
Update maintainers

### DIFF
--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -1,7 +1,8 @@
 {
   "title": "Real-time tracking of Zika virus evolution",
   "maintainers": [
-    {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
+    {"name": "Jennifer Chang", "url": "https://bedford.io/team/jennifer-chang/"},
+    {"name": "the Nextstrain team", "url": "https://nextstrain.org/team"}
   ],
   "build_url": "https://github.com/nextstrain/zika",
   "colorings": [


### PR DESCRIPTION
I'd think this could be a pretty standard pattern for "core" Nextstrain pathogens where we include the specific point person(s) alongside attribution to the larger team.

I tested this locally and it built fine.
