### PR TITLE
Add nextstrain-automation build-configs to phylogenetic worklfow

### DIFF
--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -50,6 +50,20 @@ example sequences into the `data/` directory, use the following:
 
     nextstrain build .  --configfile build-configs/ci/profiles_config.yaml
 
+### Deploying build
+
+To run the workflow and automatically deploy the build to nextstrain.org,
+you will need to have AWS credentials to run the following:
+
+```
+nextstrain build \
+    --env AWS_ACCESS_KEY_ID \
+    --env AWS_SECRET_ACCESS_KEY \
+    . \
+        deploy_all \
+        --configfile build-configs/nextstrain-automation/config.yaml
+```
+
 [Nextstrain]: https://nextstrain.org
 [augur]: https://docs.nextstrain.org/projects/augur/en/stable/
 [auspice]: https://docs.nextstrain.org/projects/auspice/en/stable/index.html

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -27,10 +27,10 @@ Once you've run the build, you can view the results with:
 
 ## Configuration
 
-Configuration takes place entirely with the `Snakefile`. This can be read
-top-to-bottom, each rule specifies its file inputs and output and also its
-parameters. There is little redirection and each rule should be able to be
-reasoned with on its own.
+Configuration for the workflow takes place entirely within the [defaults/config_zika.yaml](defaults/config_zika.yaml).
+The analysis pipeline is contained in [Snakefile](Snakefile) with included [rules](rules).
+Each rule specifies its file inputs and output and pulls its parameters from the config.
+There is little redirection and each rule should be able to be reasoned with on its own.
 
 ### Using GenBank data
 

--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,0 +1,4 @@
+custom_rules:
+  - build-configs/nextstrain-automation/deploy.smk
+
+deploy_url: "s3://nextstrain-data"

--- a/phylogenetic/build-configs/nextstrain-automation/deploy.smk
+++ b/phylogenetic/build-configs/nextstrain-automation/deploy.smk
@@ -1,0 +1,16 @@
+"""
+This part of the workflow handles automatic deployments of the zika build.
+
+Uploads the build defined as the default output of the workflow through
+the `all` rule from Snakefille
+"""
+
+rule deploy_all:
+    input: *rules.all.input
+    output: touch("results/deploy_all.done")
+    params:
+        deploy_url = config["deploy_url"]
+    shell:
+        """
+        nextstrain remote upload {params.deploy_url} {input}
+        """


### PR DESCRIPTION
## Description of proposed changes

Adds a custom config and rules for deploying the final Auspice dataset of the phylogenetic workflow. 

I had originally added this as part of the work to create automation workflows via GH Actions, but this seems like a self-contained change that would be good to merge earlier.

I tested locally and this config was also used as part of my [testing GH Action runs](https://github.com/nextstrain/zika/actions/runs/8444547115/job/23130345210#step:8:25). 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
