### PR TITLE
Fix automation hash

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -96,7 +96,7 @@ jobs:
             key="${s3path#*/}"
 
             s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
-            echo "${s3_hash}" >> ingest-output-sha256sum
+            echo "${s3_hash}" | tee -a ingest-output-sha256sum
           done
 
       - name: Check cache

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Get sha256sum
         id: get-sha256sum
+        env:
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
           s3_urls=(
             "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"


### PR DESCRIPTION
## Description of proposed changes

Adds `AWS_DEFAULT_REGION` envvar to the `check-new-data` jobs to ensure that the `aws s3api head-object` calls work properly. I always forget this needs to be set in a brand new environment 🤦‍♀️ 

Outside of this PR, I also added `AWS_DEFAULT_REGION` to the shared [Nextstrain GitHub organization variables](https://github.com/organizations/nextstrain/settings/variables/actions). 

## Related issue(s)

- Follow up on #52 
- Resolves #53 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] [Test run](https://github.com/nextstrain/zika/actions/runs/8606131049) used the [correct hashes from S3 files](https://github.com/nextstrain/zika/actions/runs/8606131049/job/23583942629#step:2:24)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
