### PR TITLE
Add independent ingest and phylogenetic GH Action workflows

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -42,30 +42,10 @@ jobs:
   ingest:
     permissions:
       id-token: write
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    uses: ./.github/workflows/ingest.yaml
     secrets: inherit
     with:
-      # Starting with the default docker runtime
-      # We can migrate to AWS Batch when/if we need to for more resources or if
-      # the job runs longer than the GH Action limit of 6 hours.
-      runtime: docker
-      env: |
-        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.ingest_image }}
-      run: |
-        nextstrain build \
-          --env AWS_ACCESS_KEY_ID \
-          --env AWS_SECRET_ACCESS_KEY \
-          ingest \
-            upload_all \
-            --configfile build-configs/nextstrain-automation/config.yaml
-      # Specifying artifact name to differentiate ingest build outputs from
-      # the phylogenetic build outputs
-      artifact-name: ingest-build-output
-      artifact-paths: |
-        ingest/results/
-        ingest/benchmarks/
-        ingest/logs/
-        ingest/.snakemake/log/
+      image: ${{ inputs.ingest_image }}
 
   # Check if ingest results include new data by checking for the cache
   # of the file with the results' Metadata.sh256sum (which should have been added within upload-to-s3)
@@ -114,28 +94,7 @@ jobs:
     if: ${{ needs.check-new-data.outputs.cache-hit != 'true' }}
     permissions:
       id-token: write
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    uses: ./.github/workflows/phylogenetic.yaml
     secrets: inherit
     with:
-      # Starting with the default docker runtime
-      # We can migrate to AWS Batch when/if we need to for more resources or if
-      # the job runs longer than the GH Action limit of 6 hours.
-      runtime: docker
-      env: |
-        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.phylogenetic_image }}
-      run: |
-        nextstrain build \
-          --env AWS_ACCESS_KEY_ID \
-          --env AWS_SECRET_ACCESS_KEY \
-          phylogenetic \
-            deploy_all \
-            --configfile build-configs/nextstrain-automation/config.yaml
-      # Specifying artifact name to differentiate ingest build outputs from
-      # the phylogenetic build outputs
-      artifact-name: phylogenetic-build-output
-      artifact-paths: |
-        phylogenetic/auspice/
-        phylogenetic/results/
-        phylogenetic/benchmarks/
-        phylogenetic/logs/
-        phylogenetic/.snakemake/log/
+      image: ${{ inputs.phylogenetic_image }}

--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -23,9 +23,35 @@ on:
         description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
         required: false
         type: string
+      trial_name:
+        description: |
+          Trial name for outputs.
+          If not set, outputs will overwrite files at s3://nextstrain-data/files/workflows/zika/
+          If set, outputs will be uploaded to s3://nextstrain-data/files/workflows/zika/trials/<trial_name>/
+        required: false
+        type: string
 
 jobs:
+  set_config_overrides:
+    runs-on: ubuntu-latest
+    steps:
+      - id: config
+        name: Set config overrides
+        env:
+          TRIAL_NAME: ${{ inputs.trial_name }}
+        run: |
+          config=""
+          if [[ "$TRIAL_NAME" ]]; then
+            config+="--config"
+            config+=" s3_dst='s3://nextstrain-data/files/workflows/zika/trials/"$TRIAL_NAME"'"
+          fi
+
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+    outputs:
+      config_overrides: ${{ steps.config.outputs.config }}
+
   ingest:
+    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -37,13 +63,15 @@ jobs:
       runtime: docker
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
       run: |
         nextstrain build \
           --env AWS_ACCESS_KEY_ID \
           --env AWS_SECRET_ACCESS_KEY \
           ingest \
             upload_all \
-            --configfile build-configs/nextstrain-automation/config.yaml
+            --configfile build-configs/nextstrain-automation/config.yaml \
+            $CONFIG_OVERRIDES
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs
       artifact-name: ingest-build-output

--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -1,0 +1,47 @@
+name: Ingest
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+
+jobs:
+  ingest:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+      run: |
+        nextstrain build \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
+          ingest \
+            upload_all \
+            --configfile build-configs/nextstrain-automation/config.yaml
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: ingest-build-output
+      artifact-paths: |
+        ingest/results/
+        ingest/benchmarks/
+        ingest/logs/
+        ingest/.snakemake/log/

--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -17,6 +17,13 @@ on:
         required: false
         type: string
 
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+
 jobs:
   ingest:
     permissions:

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -30,6 +30,18 @@ on:
           If set, builds will be deployed to s3://nextstrain-staging/zika_trials_<trial_name>_*
         required: false
         type: string
+      sequences_url:
+        description: |
+          URL for a sequences.fasta.zst file.
+          If not provided, will use default sequences_url from phylogenetic/defaults/config_zika.yaml
+        required: false
+        type: string
+      metadata_url:
+        description: |
+          URL for a metadata.tsv.zst file.
+          If not provided, will use default metadata_url from phylogenetic/defaults/config_zika.yaml
+        required: false
+        type: string
 
 jobs:
   set_config_overrides:
@@ -39,11 +51,26 @@ jobs:
         name: Set config overrides
         env:
           TRIAL_NAME: ${{ inputs.trial_name }}
+          SEQUENCES_URL: ${{ inputs.sequences_url }}
+          METADATA_URL: ${{ inputs.metadata_url }}
         run: |
           config=""
-          if [[ "$TRIAL_NAME" ]]; then
+          if [[ "$TRIAL_NAME" || "$SEQUENCES_URL" || "$METADATA_URL" ]]; then
+
             config+="--config"
-            config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
+
+            if [[ "$TRIAL_NAME" ]]; then
+              config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
+            fi
+
+            if [[ "$SEQUENCES_URL" ]]; then
+              config+=" sequences_url='"$SEQUENCES_URL"'"
+            fi
+
+            if [[ "$METADATA_URL" ]]; then
+              config+=" metadata_url='"$METADATA_URL"'"
+            fi
+
           fi
 
           echo "config=$config" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -55,22 +55,21 @@ jobs:
           METADATA_URL: ${{ inputs.metadata_url }}
         run: |
           config=""
-          if [[ "$TRIAL_NAME" || "$SEQUENCES_URL" || "$METADATA_URL" ]]; then
 
-            config+="--config"
+          if [[ "$TRIAL_NAME" ]]; then
+            config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
+          fi
 
-            if [[ "$TRIAL_NAME" ]]; then
-              config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
-            fi
+          if [[ "$SEQUENCES_URL" ]]; then
+            config+=" sequences_url='"$SEQUENCES_URL"'"
+          fi
 
-            if [[ "$SEQUENCES_URL" ]]; then
-              config+=" sequences_url='"$SEQUENCES_URL"'"
-            fi
+          if [[ "$METADATA_URL" ]]; then
+            config+=" metadata_url='"$METADATA_URL"'"
+          fi
 
-            if [[ "$METADATA_URL" ]]; then
-              config+=" metadata_url='"$METADATA_URL"'"
-            fi
-
+          if [[ $config ]]; then
+            config="--config $config"
           fi
 
           echo "config=$config" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -1,0 +1,48 @@
+name: Phylogenetic
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Specific container image to use for phylogenetic workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+
+jobs:
+  phylogenetic:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+      run: |
+        nextstrain build \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
+          phylogenetic \
+            deploy_all \
+            --configfile build-configs/nextstrain-automation/config.yaml
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: phylogenetic-build-output
+      artifact-paths: |
+        phylogenetic/auspice/
+        phylogenetic/results/
+        phylogenetic/benchmarks/
+        phylogenetic/logs/
+        phylogenetic/.snakemake/log/

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -23,9 +23,35 @@ on:
         description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
         required: false
         type: string
+      trial_name:
+        description: |
+          Trial name for deploying builds.
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/zika*
+          If set, builds will be deployed to s3://nextstrain-staging/zika_trials_<trial_name>_*
+        required: false
+        type: string
 
 jobs:
+  set_config_overrides:
+    runs-on: ubuntu-latest
+    steps:
+      - id: config
+        name: Set config overrides
+        env:
+          TRIAL_NAME: ${{ inputs.trial_name }}
+        run: |
+          config=""
+          if [[ "$TRIAL_NAME" ]]; then
+            config+="--config"
+            config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
+          fi
+
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+    outputs:
+      config_overrides: ${{ steps.config.outputs.config }}
+
   phylogenetic:
+    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -37,13 +63,15 @@ jobs:
       runtime: docker
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
       run: |
         nextstrain build \
           --env AWS_ACCESS_KEY_ID \
           --env AWS_SECRET_ACCESS_KEY \
           phylogenetic \
             deploy_all \
-            --configfile build-configs/nextstrain-automation/config.yaml
+            --configfile build-configs/nextstrain-automation/config.yaml \
+            $CONFIG_OVERRIDES
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs
       artifact-name: phylogenetic-build-output

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -17,6 +17,13 @@ on:
         required: false
         type: string
 
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+
 jobs:
   phylogenetic:
     permissions:

--- a/phylogenetic/defaults/config_zika.yaml
+++ b/phylogenetic/defaults/config_zika.yaml
@@ -1,3 +1,8 @@
+# Sequences must be FASTA and metadata must be TSV
+# Both files must be zstd compressed
+sequences_url: "https://data.nextstrain.org/files/workflows/zika/sequences.fasta.zst"
+metadata_url: "https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"
+
 strain_id_field: "accession"
 display_strain_field: "strain"
 

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -27,8 +27,8 @@ rule download:
         sequences = "data/sequences.fasta.zst",
         metadata = "data/metadata.tsv.zst"
     params:
-        sequences_url = "https://data.nextstrain.org/files/workflows/zika/sequences.fasta.zst",
-        metadata_url = "https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"
+        sequences_url = config["sequences_url"],
+        metadata_url = config["metadata_url"],
     shell:
         """
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}


### PR DESCRIPTION
## Description of proposed changes

Splits the `ingest-to-phylogenetic` GH Action workflow added in #52 into independent reusable workflows.
The reusable GH Action workflows `ingest` and `phylogenetic` are then called from within `ingest-to-phylogenetic`, but they can also be run independently and with trial names.

This splits the use of the workflows as 

- `ingest-to-phylogenetic.yaml` for scheduled, automated runs
- `ingest.yaml` for manual trial runs of the ingest workflow
- `phylogenetic.yaml` for manual trial runs of the phylogenetic workflow OR forced runs that don't check the cache

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run of `ingest-to-phylogenetic`](https://github.com/nextstrain/zika/actions/runs/8668950593/attempts/1) (with cache)
- [x] [Test run of `ingest-to-phylogenetic`](https://github.com/nextstrain/zika/actions/runs/8668950593) (after manually deleting cache)
- [x] [Test run of `ingest`](https://github.com/nextstrain/zika/actions/runs/8668996855) (with trial name)
- [x] [Test run of `phylogenetic`](https://github.com/nextstrain/zika/actions/runs/8669045733) (with trial name and custom input URLs that point to output files of the trial ingest run)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
