### PR TITLE
phylogenetic: Add root-sequence.json to rule `all`

### DIFF
--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -3,6 +3,7 @@ configfile: "defaults/config_zika.yaml"
 rule all:
     input:
         auspice_json = "auspice/zika.json",
+        root_sequence = "auspice/zika_root-sequence.json"
 
 include: "rules/prepare_sequences.smk"
 include: "rules/merge_sequences_usvi.smk"


### PR DESCRIPTION
## Description of proposed changes

Explicitly state that the root-sequence.json file is an expected output of the core phylogenetic workflow.

This also ensures that the Nextstrain automation rule `deploy_all` will include the root-sequence.json in the upload.

## Related issue(s)

Follow up to https://github.com/nextstrain/zika/pull/51

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
