### PR TITLE
phylogenetic: Use inline root sequence

### DIFF
--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -2,8 +2,7 @@ configfile: "defaults/config_zika.yaml"
 
 rule all:
     input:
-        auspice_json = "auspice/zika.json",
-        root_sequence = "auspice/zika_root-sequence.json"
+        auspice_json = "auspice/zika.json"
 
 include: "rules/prepare_sequences.smk"
 include: "rules/merge_sequences_usvi.smk"

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -38,8 +38,7 @@ rule export:
         auspice_config = "defaults/auspice_config.json",
         description = "defaults/description.md"
     output:
-        auspice_json = "results/raw_zika.json",
-        root_sequence = "results/raw_zika_root-sequence.json",
+        auspice_json = "results/raw_zika.json"
     params:
         strain_id = config.get("strain_id_field", "strain"),
     shell:
@@ -52,18 +51,16 @@ rule export:
             --colors {input.colors} \
             --auspice-config {input.auspice_config} \
             --description {input.description} \
-            --include-root-sequence \
+            --include-root-sequence-inline \
             --output {output.auspice_json}
         """
 
 rule final_strain_name:
     input:
         auspice_json="results/raw_zika.json",
-        metadata="data/metadata_all.tsv",
-        root_sequence="results/raw_zika_root-sequence.json",
+        metadata="data/metadata_all.tsv"
     output:
-        auspice_json="auspice/zika.json",
-        root_sequence="auspice/zika_root-sequence.json",
+        auspice_json="auspice/zika.json"
     params:
         strain_id=config["strain_id_field"],
         display_strain_field=config.get("display_strain_field", "strain"),
@@ -75,6 +72,4 @@ rule final_strain_name:
             --input-auspice-json {input.auspice_json} \
             --display-strain-name {params.display_strain_field} \
             --output {output.auspice_json}
-
-        cp {input.root_sequence} {output.root_sequence}
         """


### PR DESCRIPTION
Based on feedback from @jameshadfield in
https://github.com/nextstrain/zika/pull/56#issuecomment-2058060422

Looking at the existing dataset files on S3,
the 5 KiB root-sequence.json is pretty negligible when the main Auspice JSON is only 163 KiB. Nextstrain datasets are limited by the 500MB memory cap in Chrome,¹ so we'd be fine adding the root sequence inline.

¹ https://github.com/nextstrain/auspice/issues/1622

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
