### PR TITLE
ingest: fix csvtk quotes

### DIFF
--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -64,9 +64,11 @@ rule format_ncbi_dataset_report:
             --package {input.dataset_package} \
             --fields {params.ncbi_datasets_fields:q} \
             --elide-header \
+            | csvtk fix-quotes -Ht \
             | csvtk add-header -t -n {params.ncbi_datasets_fields:q} \
             | csvtk rename -t -f accession -n accession-rev \
-            | csvtk -tl mutate -f accession-rev -n accession -p "^(.+?)\." \
+            | csvtk -t mutate -f accession-rev -n accession -p "^(.+?)\." \
+            | csvtk del-quotes -t \
             | tsv-select -H -f accession --rest last \
             > {output.ncbi_dataset_tsv}
         """


### PR DESCRIPTION
The automated ingest workflow failed with a csvtk quoting error.¹ Following https://github.com/nextstrain/docker-base/pull/209, we can now use `csvtk fix-quotes` and `csvtk del-quotes` to work around the quoting issue.

¹ https://github.com/nextstrain/zika/actions/runs/8926866948/job/24518932039#step:8:139

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial ingest run](https://github.com/nextstrain/zika/actions/runs/8928588201)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
