### PR TITLE
GH Action workflows: set config overrides in main job

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -60,17 +60,17 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         TRIAL_NAME: ${{ inputs.trial_name }}
       run: |
-        config=""
+        declare -a config
+
         if [[ "$TRIAL_NAME" ]]; then
-          config+="--config"
-          config+=" s3_dst='s3://nextstrain-data/files/workflows/zika/trials/"$TRIAL_NAME"'"
+          config+=("s3_dst=s3://nextstrain-data/files/workflows/zika/trials/$TRIAL_NAME")
         fi
 
         nextstrain build \
           ingest \
             upload_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
-            $config
+            --config "${config[@]}"
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs
       artifact-name: ingest-build-output

--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -46,26 +46,7 @@ on:
         type: string
 
 jobs:
-  set_config_overrides:
-    runs-on: ubuntu-latest
-    steps:
-      - id: config
-        name: Set config overrides
-        env:
-          TRIAL_NAME: ${{ inputs.trial_name }}
-        run: |
-          config=""
-          if [[ "$TRIAL_NAME" ]]; then
-            config+="--config"
-            config+=" s3_dst='s3://nextstrain-data/files/workflows/zika/trials/"$TRIAL_NAME"'"
-          fi
-
-          echo "config=$config" >> "$GITHUB_OUTPUT"
-    outputs:
-      config_overrides: ${{ steps.config.outputs.config }}
-
   ingest:
-    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -77,13 +58,19 @@ jobs:
       runtime: docker
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
-        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
+        TRIAL_NAME: ${{ inputs.trial_name }}
       run: |
+        config=""
+        if [[ "$TRIAL_NAME" ]]; then
+          config+="--config"
+          config+=" s3_dst='s3://nextstrain-data/files/workflows/zika/trials/"$TRIAL_NAME"'"
+        fi
+
         nextstrain build \
           ingest \
             upload_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
-            $CONFIG_OVERRIDES
+            $config
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs
       artifact-name: ingest-build-output

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -86,7 +86,7 @@ jobs:
           key: ingest-output-sha256sum-${{ hashFiles('ingest-output-sha256sum') }}
           lookup-only: true
 
-  set_config_overrides:
+  phylogenetic:
     # Run the workflow under two conditions
     # 1. `workflow_run` triggered `check-new-data` and there's new data (no cache hit)
     # 2. the workflow is being manually run by `workflow_dispatch`
@@ -97,39 +97,6 @@ jobs:
         (needs.check-new-data.result == 'success' && needs.check-new-data.outputs.cache-hit != 'true') ||
         github.event_name == 'workflow_dispatch'
       )
-    runs-on: ubuntu-latest
-    steps:
-      - id: config
-        name: Set config overrides
-        env:
-          TRIAL_NAME: ${{ inputs.trial_name }}
-          SEQUENCES_URL: ${{ inputs.sequences_url }}
-          METADATA_URL: ${{ inputs.metadata_url }}
-        run: |
-          config=""
-
-          if [[ "$TRIAL_NAME" ]]; then
-            config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
-          fi
-
-          if [[ "$SEQUENCES_URL" ]]; then
-            config+=" sequences_url='"$SEQUENCES_URL"'"
-          fi
-
-          if [[ "$METADATA_URL" ]]; then
-            config+=" metadata_url='"$METADATA_URL"'"
-          fi
-
-          if [[ $config ]]; then
-            config="--config $config"
-          fi
-
-          echo "config=$config" >> "$GITHUB_OUTPUT"
-    outputs:
-      config_overrides: ${{ steps.config.outputs.config }}
-
-  phylogenetic:
-    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -141,13 +108,33 @@ jobs:
       runtime: docker
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
-        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
+        TRIAL_NAME: ${{ inputs.trial_name }}
+        SEQUENCES_URL: ${{ inputs.sequences_url }}
+        METADATA_URL: ${{ inputs.metadata_url }}
       run: |
+        config=""
+
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
+        fi
+
+        if [[ "$SEQUENCES_URL" ]]; then
+          config+=" sequences_url='"$SEQUENCES_URL"'"
+        fi
+
+        if [[ "$METADATA_URL" ]]; then
+          config+=" metadata_url='"$METADATA_URL"'"
+        fi
+
+        if [[ $config ]]; then
+          config="--config $config"
+        fi
+
         nextstrain build \
           phylogenetic \
             deploy_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
-            $CONFIG_OVERRIDES
+            $config
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs
       artifact-name: phylogenetic-build-output

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -112,29 +112,25 @@ jobs:
         SEQUENCES_URL: ${{ inputs.sequences_url }}
         METADATA_URL: ${{ inputs.metadata_url }}
       run: |
-        config=""
+        declare -a config
 
         if [[ "$TRIAL_NAME" ]]; then
-          config+=" deploy_url='s3://nextstrain-staging/zika_trials_"$TRIAL_NAME"_'"
+          config+=("deploy_url=s3://nextstrain-staging/zika_trials_${TRIAL_NAME}_")
         fi
 
         if [[ "$SEQUENCES_URL" ]]; then
-          config+=" sequences_url='"$SEQUENCES_URL"'"
+          config+=("sequences_url=$SEQUENCES_URL")
         fi
 
         if [[ "$METADATA_URL" ]]; then
-          config+=" metadata_url='"$METADATA_URL"'"
-        fi
-
-        if [[ $config ]]; then
-          config="--config $config"
+          config+=("metadata_url=$METADATA_URL")
         fi
 
         nextstrain build \
           phylogenetic \
             deploy_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
-            $config
+            --config "${config[@]}"
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs
       artifact-name: phylogenetic-build-output


### PR DESCRIPTION
## Description of proposed changes

Follow up on https://github.com/nextstrain/zika/pull/81#issuecomment-2795072655

Set the config overrides within the `run` input of the phylogenetic job so that we don't have to worry about the dependency chain of the GH Action jobs.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial ingest](https://github.com/nextstrain/zika/actions/runs/14391212172)
- [x] [Trial phylo](https://github.com/nextstrain/zika/actions/runs/14391280434)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
