### PR TITLE
Support snakemake v9

### DIFF
--- a/ingest/profiles/default/config.yaml
+++ b/ingest/profiles/default/config.yaml
@@ -1,4 +1,3 @@
 cores: all
 rerun-incomplete: true
 printshellcmds: true
-reason: true


### PR DESCRIPTION
The only change needed to support Snakemake v9 was to remove a snakemake argument which was already deprecated and a no-op in v7. So I think this can be merged now (while our runtimes are still pinned to v7). 

Closes #87

Tested in a conda environment with python 3.12.2, snakemake 9.6.2, augur e6245ebd (current master, v31.2.1). 
