### PR TITLE
WIP - snakemake v8+ remote storage support

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -1,17 +1,32 @@
 # Sequences must be FASTA and metadata must be TSV
 
-# TODO XXX - remove commented lines below - only for testing the snakemake storage stuff
+# TODO XXX - fixup this mess!
 inputs:
+  # - name: ncbi
+  #   metadata: "s3://nextstrain-scratch/zika-pr-89/metadata.tsv.zst"
+  #   sequences: "s3://nextstrain-scratch/zika-pr-89/sequences.fasta.zst"
+
   - name: ncbi
     metadata: "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"
     sequences: "s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst"
-    # metadata: "https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"
-    # sequences: "https://data.nextstrain.org/files/workflows/zika/sequences.fasta.zst"
 
-additional_inputs:
+  # - name: ncbi
+  #   metadata: "https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"
+  #   sequences: "https://data.nextstrain.org/workflows/zika/sequences.fasta.zst"
+
+  # - name: usvi
+  #   metadata: s3://nextstrain-data/files/workflows/zika/metadata_usvi.tsv.zst
+  #   sequences: s3://nextstrain-data/files/workflows/zika/sequences_usvi.fasta.zst
+
+  # - name: usvi
+  #   metadata: https://data.nextstrain.org/files/workflows/zika/metadata_usvi.tsv.zst
+  #   sequences: https://data.nextstrain.org/files/workflows/zika/sequences_usvi.fasta.zst
+
+  # - name: usvi
+  #   metadata: metadata_usvi.tsv
+  #   sequences: sequences_usvi.fasta.zst
+
   - name: usvi
-    # metadata: "data/metadata_usvi.tsv"
-    # sequences: "data/sequences_usvi.fasta"
     metadata: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/metadata_usvi.tsv
     sequences: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/sequences_usvi.fasta
 

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -1,14 +1,19 @@
 # Sequences must be FASTA and metadata must be TSV
-# Both files must be zstd compressed
+
+# TODO XXX - remove commented lines below - only for testing the snakemake storage stuff
 inputs:
   - name: ncbi
     metadata: "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"
     sequences: "s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst"
+    # metadata: "https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"
+    # sequences: "https://data.nextstrain.org/files/workflows/zika/sequences.fasta.zst"
 
 additional_inputs:
   - name: usvi
     metadata: "data/metadata_usvi.tsv"
     sequences: "data/sequences_usvi.fasta"
+    # metadata: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/metadata_usvi.tsv
+    # sequences: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/sequences.fasta
 
 # Config files
 exclude: "exclude.txt"
@@ -41,3 +46,4 @@ traits:
     - region
     - country
   sampling_bias_correction: 3
+# 

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -30,6 +30,10 @@ inputs:
     metadata: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/metadata_usvi.tsv
     sequences: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/sequences_usvi.fasta
 
+  # - name: usvi
+  #   metadata: gs://nextstrain-data/files/workflows/zika/metadata_usvi.tsv.zst
+  #   sequences: gs://nextstrain-data/files/workflows/zika/sequences_usvi.fasta.zst
+
 # Config files
 exclude: "exclude.txt"
 reference: "reference.gb"

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -10,10 +10,10 @@ inputs:
 
 additional_inputs:
   - name: usvi
-    metadata: "data/metadata_usvi.tsv"
-    sequences: "data/sequences_usvi.fasta"
-    # metadata: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/metadata_usvi.tsv
-    # sequences: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/sequences.fasta
+    # metadata: "data/metadata_usvi.tsv"
+    # sequences: "data/sequences_usvi.fasta"
+    metadata: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/metadata_usvi.tsv
+    sequences: https://raw.githubusercontent.com/nextstrain/zika/refs/heads/main/phylogenetic/data/sequences_usvi.fasta
 
 # Config files
 exclude: "exclude.txt"

--- a/phylogenetic/rules/merge_inputs.smk
+++ b/phylogenetic/rules/merge_inputs.smk
@@ -22,55 +22,7 @@ This part of the workflow usually includes the following steps:
 
 """
 
-
-# ------------- helper functions to collect, merge & download input files ------------------- #
-NEXTSTRAIN_PUBLIC_BUCKET = "s3://nextstrain-data/"
-
-def _parse_config_input(input):
-    """
-    Parses information from an individual config-defined input, i.e. an element within `config.inputs` or `config.additional_inputs`
-    and returns information snakemake rules can use to obtain the underlying data.
-
-    The structure of `input` is a dictionary with keys:
-    - name:string (required)
-    - metadata:string (optional) - a s3 URI or a local file path
-    - sequences:string (optional) - a s3 URI or a local file path
-
-    Returns a dictionary with optional keys:
-    - metadata:string - the relative path to the metadata file. If the original data was remote then this represents
-      the output of a rule which downloads the file
-    - metadata_location:string - the URI for the remote file if applicable else `None`
-    - sequences:string - the relative path to the sequences FASTA. If the original data was remote then this represents
-      the output of a rule which downloads the file
-    - sequences_location:string - the URI for the remote file if applicable else `None`
-
-    Raises InvalidConfigError
-    """
-    name = input['name']
-
-    info = {'metadata': None, 'metadata_location': None, 'sequences': None, 'sequences_location': None}
-
-    def _source(uri, *,  s3, local):
-        if uri.startswith('s3://'):
-            return s3
-        elif uri.lower().startswith(('http://','https://')):
-            raise InvalidConfigError("Workflow cannot yet handle HTTP[S] inputs")
-        # USVI files are expected to be part of the workflow source,
-        # and are _not_ expected to be provided via the analysis directory
-        elif uri.startswith('data/metadata_usvi.tsv') or uri.startswith('data/sequences_usvi.fasta'):
-            return workflow.source_path("../" + uri)
-        return local
-
-    if location:=input.get('metadata', False):
-        info['metadata'] = _source(location,  s3=f"data/{name}/metadata.tsv", local=location)
-        info['metadata_location'] = _source(location,  s3=location, local=None)
-
-    if location:=input.get('sequences', False):
-        info['sequences'] = _source(location,  s3=f"data/{name}/sequences.fasta", local=location)
-        info['sequences_location'] = _source(location,  s3=location, local=None)
-
-    return info
-
+include: "remote_files.smk"
 
 def _gather_inputs():
     all_inputs = [*config['inputs'], *config.get('additional_inputs', [])]
@@ -85,7 +37,11 @@ def _gather_inputs():
     if not all(['name' in i and ('sequences' in i or 'metadata' in i) for i in all_inputs]):
         raise InvalidConfigError("Each input (config.inputs and config.additional_inputs) must have a 'name' and 'metadata' and/or 'sequences'")
 
-    return {i['name']: _parse_config_input(i) for i in all_inputs}
+    available_keys = set(['name', 'metadata', 'sequences'])
+    if any([len(set(el.keys())-available_keys)>0 for el in all_inputs]):
+        raise InvalidConfigError(f"Each input (config.inputs and config.additional_inputs) can only include keys of {', '.join(available_keys)}")
+
+    return {el['name']: {k:(v if k=='name' else path_or_url(v)) for k,v in el.items()} for el in all_inputs}
 
 input_sources = _gather_inputs()
 
@@ -96,44 +52,6 @@ def input_metadata(wildcards):
 def input_sequences(wildcards):
     inputs = [info['sequences'] for info in input_sources.values() if info.get('sequences', None)]
     return inputs[0] if len(inputs)==1 else "results/sequences_merged.fasta"
-
-rule download_s3_sequences:
-    output:
-        sequences = "data/{input_name}/sequences.fasta",
-    log:
-        "logs/{input_name}/download_s3_sequences.txt",
-    benchmark:
-        "benchmarks/{input_name}/download_s3_sequences.txt"
-    params:
-        address = lambda w: input_sources[w.input_name]['sequences_location'],
-        no_sign_request=lambda w: "--no-sign-request" \
-            if input_sources[w.input_name]['sequences_location'].startswith(NEXTSTRAIN_PUBLIC_BUCKET) \
-            else "",
-    shell:
-        r"""
-        exec &> >(tee {log:q})
-
-        aws s3 cp {params.no_sign_request:q} {params.address:q} - | zstd -d > {output.sequences}
-        """
-
-rule download_s3_metadata:
-    output:
-        metadata = "data/{input_name}/metadata.tsv",
-    log:
-        "logs/{input_name}/download_s3_metadata.txt",
-    benchmark:
-        "benchmarks/{input_name}/download_s3_metadata.txt"
-    params:
-        address = lambda w: input_sources[w.input_name]['metadata_location'],
-        no_sign_request=lambda w: "--no-sign-request" \
-            if input_sources[w.input_name]['metadata_location'].startswith(NEXTSTRAIN_PUBLIC_BUCKET) \
-            else "",
-    shell:
-        r"""
-        exec &> >(tee {log:q})
-
-        aws s3 cp {params.no_sign_request:q} {params.address:q} - | zstd -d > {output.metadata}
-        """
 
 rule merge_metadata:
     """
@@ -180,5 +98,3 @@ rule merge_sequences:
 
         seqkit rmdup {input:q} > {output.sequences:q}
         """
-
-# -------------------------------------------------------------------------------------------- #

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -61,6 +61,15 @@ rule filter:
             --min-length {params.min_length:q}
         """
 
+rule upload_filter:
+    """TESTING ONLY TODO XXX REMOVE"""
+    input: "results/filtered.fasta"
+    output: path_or_url("s3://nextstrain-scratch/testing-zika-filtered.fasta")
+    shell:
+        r"""
+        cp {input[0]} {output[0]}
+        """
+
 rule align:
     """
     Aligning sequences to {input.reference}

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -61,14 +61,41 @@ rule filter:
             --min-length {params.min_length:q}
         """
 
-rule upload_filter:
-    """TESTING ONLY TODO XXX REMOVE"""
-    input: "results/filtered.fasta"
-    output: path_or_url("s3://nextstrain-scratch/testing-zika-filtered.fasta")
-    shell:
-        r"""
-        cp {input[0]} {output[0]}
-        """
+
+# rule upload_filter:
+#     """TESTING ONLY TODO XXX REMOVE"""
+#     input:
+#         sequences = input_sequences,
+#         metadata = input_metadata,
+#         exclude = resolve_config_path(config["exclude"]),
+#     output:
+#         sequences = path_or_url("s3://nextstrain-scratch/zika-pr-89/filtered.fasta")
+#     params:
+#         group_by = as_list(config["filter"]["group_by"]),
+#         sequences_per_group = config["filter"]["sequences_per_group"],
+#         min_date = config["filter"]["min_date"],
+#         min_length = config["filter"]["min_length"],
+#         strain_id = config.get("strain_id_field", "strain"),
+#     log:
+#         "logs/filter.txt",
+#     benchmark:
+#         "benchmarks/filter.txt"
+#     shell:
+#         r"""
+#         exec &> >(tee {log:q})
+
+#         augur filter \
+#             --sequences {input.sequences:q} \
+#             --metadata {input.metadata:q} \
+#             --metadata-id-columns {params.strain_id:q} \
+#             --exclude {input.exclude:q} \
+#             --output-sequences {output.sequences:q} \
+#             --group-by {params.group_by:q} \
+#             --sequences-per-group {params.sequences_per_group:q} \
+#             --min-date {params.min_date:q} \
+#             --min-length {params.min_length:q}
+#         """
+
 
 rule align:
     """

--- a/phylogenetic/rules/remote_files.smk
+++ b/phylogenetic/rules/remote_files.smk
@@ -86,14 +86,6 @@ def _storage_http(*, keep_local, retries) -> snakemake.storage.StorageProviderPr
     _storage_registry['http'] = storage.http
     return _storage_registry['http']
 
-def _storage_gcs(*, keep_local, retries) -> snakemake.storage.StorageProviderProxy:
-    if provider:=_storage_registry.get('gcs', None):
-        return provider
-
-    storage:
-        provider="gcs",
-        retries=retries,
-        keep_local=keep_local
 
 def path_or_url(uri, *, keep_local=True, retries=2) -> str:
     """
@@ -143,6 +135,7 @@ def path_or_url(uri, *, keep_local=True, retries=2) -> str:
         return _storage_http(keep_local=keep_local, retries=retries)(uri)
 
     if info.scheme in ['gs', 'gcs']:
-        return _storage_gcs(keep_local=keep_local, retries=retries)(uri)
+        raise Exception(f"Google Storage is not yet implemented for nextstrain workflows (attempting to access {uri!r}).\n"
+            "Please get in touch if you require this functionality and we can add it to our workflows")
 
     raise Exception(f"Input address {uri!r} (scheme={info.scheme!r}) is from a non-supported remote")

--- a/phylogenetic/rules/remote_files.smk
+++ b/phylogenetic/rules/remote_files.smk
@@ -1,0 +1,82 @@
+"""
+Helper functions to set-up storage plugins for remote inputs/outputs.
+See the docstring of `path_or_url` for usage instructions.
+
+<https://snakemake.readthedocs.io/en/stable/snakefiles/storage.html>
+"""
+
+from urllib.parse import urlparse
+
+PUBLIC_BUCKETS = set(['nextstrain-data']) # TODO XXX
+
+_storage_registry = {} # keeps track of registered storage plugins to enable reuse
+
+def _storage_s3(*, bucket, keep_local, force_signed):
+    """
+    Returns a Snakemake storage plugin for S3 endpoints
+    """
+    retries=2 # num S3 retries attempted
+
+    # If the bucket is public then we make an unsigned request (i.e. no AWS credentials
+    # need to be set). Note that this won't work for uploads.
+    if not force_signed and bucket in PUBLIC_BUCKETS:
+        if provider:=_storage_registry.get('s3_unsigned', None):
+            return provider
+
+        from botocore import UNSIGNED
+        storage s3_unsigned:
+            provider="s3",
+            signature_version=UNSIGNED,
+            retries=retries, 
+            keep_local=keep_local,
+
+        _storage_registry['s3_unsigned'] = storage.s3_unsigned
+        return _storage_registry['s3_unsigned']
+
+    # Default: resource fetched via a signed request, which will require AWS credentials
+    if provider:=_storage_registry.get('s3_signed', None):
+        return provider
+
+    # the tag appears in the local file path, so reference 'signed' to give a hint about credential errors
+    storage s3_signed:
+        provider="s3",
+        retries=retries, 
+        keep_local=keep_local,
+
+    _storage_registry['s3_signed'] = storage.s3_signed
+    return _storage_registry['s3_signed']
+
+def _storage_http(*, keep_local):
+    if provider:=_storage_registry.get('http', None):
+        return provider
+
+    storage:
+        provider="http",
+        allow_redirects=True,
+        supports_head=True,
+        keep_local=keep_local,
+
+    _storage_registry['http'] = storage.http
+    return _storage_registry['http']
+
+def path_or_url(uri, *, keep_local=True, force_signed=False):
+    """
+    Returns the URI wrapped by an applicable storage plugin.
+    Local filepaths will be returned unchanged.
+
+    TODO XXX - document usage more thoroughly
+    """
+    info = urlparse(uri)
+
+    if info.scheme=='': # local
+        return uri      # no storage wrapper
+
+    if info.scheme=='s3':
+        return _storage_s3(bucket=info.netloc, keep_local=keep_local, force_signed=force_signed)(uri)
+
+    if info.scheme in ['http', 'https']:
+        return _storage_http(keep_local=keep_local)(uri)
+    
+    # TODO XXX - Google? We allowed this in ncov <https://github.com/nextstrain/ncov/blob/41cf6470d3140963ff3e02c29241f80ae8ed9c33/workflow/snakemake_rules/remote_files.smk#L62>
+
+    raise Exception(f"Input address {uri!r} (scheme={info.scheme!r}) is from a non-supported remote")

--- a/phylogenetic/rules/remote_files.smk
+++ b/phylogenetic/rules/remote_files.smk
@@ -2,28 +2,41 @@
 Helper functions to set-up storage plugins for remote inputs/outputs.
 See the docstring of `path_or_url` for usage instructions.
 
-<https://snakemake.readthedocs.io/en/stable/snakefiles/storage.html>
+The errors raised by storage plugins are often confusing. For instance,
+a HTTP 404 error will result in a `MissingInputException` with little
+hint as to the underlying issue. S3 credentials errors are similarly
+confusing and we attempt to check these ourselves to improve UX here.
 """
 
 from urllib.parse import urlparse
 
-PUBLIC_BUCKETS = set(['nextstrain-data']) # TODO XXX
+# Keep a list of known public buckets, which we'll allow uncredentialled (unsigned) access to
+# We could make this config-definable in the future
+PUBLIC_BUCKETS = set(['nextstrain-data'])
 
-_storage_registry = {} # keeps track of registered storage plugins to enable reuse
+# Keep track of registered storage plugins to enable reuse
+_storage_registry = {}
 
-def _storage_s3(*, bucket, keep_local, force_signed):
+class RemoteFilesMissingCredentials(Exception):
+    pass
+
+def _storage_s3(*, bucket, keep_local, retries) -> snakemake.storage.StorageProviderProxy:
     """
-    Returns a Snakemake storage plugin for S3 endpoints
+    Registers and returns an instance of snakemake-storage-plugin-s3
     """
-    retries=2 # num S3 retries attempted
+    # If the bucket is public then we may use an unsigned request which has the nice UX
+    # of not needing credentials to be present. If we've made other signed requests _or_
+    # credentials are present then we just sign everything. This has implications for upload:
+    # if you attempt to upload to a public bucket without credentials then we allow that here
+    # and you'll get a subsequent `AccessDenied` error when the upload is attempted.
+    if bucket in PUBLIC_BUCKETS and \
+        "s3_signed" not in _storage_registry and \
+        ("s3_unsigned" in _storage_registry or not _aws_credentials_present()):
 
-    # If the bucket is public then we make an unsigned request (i.e. no AWS credentials
-    # need to be set). Note that this won't work for uploads.
-    if not force_signed and bucket in PUBLIC_BUCKETS:
         if provider:=_storage_registry.get('s3_unsigned', None):
             return provider
 
-        from botocore import UNSIGNED
+        from botocore import UNSIGNED # dependency of snakemake-storage-plugin-s3
         storage s3_unsigned:
             provider="s3",
             signature_version=UNSIGNED,
@@ -33,9 +46,13 @@ def _storage_s3(*, bucket, keep_local, force_signed):
         _storage_registry['s3_unsigned'] = storage.s3_unsigned
         return _storage_registry['s3_unsigned']
 
-    # Default: resource fetched via a signed request, which will require AWS credentials
+    # Resource fetched/uploaded via a signed request, which will require AWS credentials
     if provider:=_storage_registry.get('s3_signed', None):
         return provider
+
+    # Enforce the presence of credentials to paper over <https://github.com/snakemake/snakemake/issues/3663>
+    if not _aws_credentials_present():
+        raise RemoteFilesMissingCredentials()
 
     # the tag appears in the local file path, so reference 'signed' to give a hint about credential errors
     storage s3_signed:
@@ -46,7 +63,16 @@ def _storage_s3(*, bucket, keep_local, force_signed):
     _storage_registry['s3_signed'] = storage.s3_signed
     return _storage_registry['s3_signed']
 
-def _storage_http(*, keep_local):
+def _aws_credentials_present() -> bool:
+    import boto3 # dependency of snakemake-storage-plugin-s3
+    session = boto3.Session()
+    creds = session.get_credentials()
+    return creds is not None
+
+def _storage_http(*, keep_local, retries) -> snakemake.storage.StorageProviderProxy:
+    """
+    Registers and returns an instance of snakemake-storage-plugin-http
+    """
     if provider:=_storage_registry.get('http', None):
         return provider
 
@@ -55,25 +81,52 @@ def _storage_http(*, keep_local):
         allow_redirects=True,
         supports_head=True,
         keep_local=keep_local,
+        retries=retries,
 
     _storage_registry['http'] = storage.http
     return _storage_registry['http']
 
-def _storage_gcs(*, keep_local):
+def _storage_gcs(*, keep_local, retries) -> snakemake.storage.StorageProviderProxy:
     if provider:=_storage_registry.get('gcs', None):
         return provider
 
     storage:
         provider="gcs",
-        retries=2,
+        retries=retries,
         keep_local=keep_local
 
-def path_or_url(uri, *, keep_local=True, force_signed=False):
+def path_or_url(uri, *, keep_local=True, retries=2) -> str:
     """
-    Returns the URI wrapped by an applicable storage plugin.
-    Local filepaths will be returned unchanged.
+    Intended for use in Snakemake inputs / outputs to transparently use remote
+    resources. Returns the URI wrapped by an applicable storage plugin. Local
+    filepaths will be returned unchanged.
 
-    TODO XXX - document usage more thoroughly
+    For example, the following rule will download inputs from HTTPs and upload
+    the output to S3:
+
+        rule filter:
+            input:
+                sequences = path_or_url("https://data.nextstrain.org/files/workflows/zika/sequences.fasta.zst"),
+                metadata = path_or_url("https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"),
+            output:
+                sequences = path_or_url("s3://nextstrain-scratch/filtered.fasta")
+            shell:
+                r'''
+                augur filter \
+                    --sequences {input.sequences:q} \
+                    --metadata {input.metadata:q} \
+                    --metadata-id-columns accession \
+                    --output-sequences {output.sequences:q}
+                '''
+
+    If `keep_local` is True (the default) then downloaded/uploaded files will
+    remain in `.snakemake/storage/`. The presence of a previously downloaded
+    file (via `keep_local=True`) does not guarantee that the file will not be
+    re-downloaded if the storage plugin decides the local file is out of date.
+
+    See <https://snakemake.readthedocs.io/en/stable/snakefiles/storage.html> for
+    more information on Snakemake storage plugins. Note: various snakemake
+    plugins will be required depending on the URIs provided.
     """
     info = urlparse(uri)
 
@@ -81,12 +134,15 @@ def path_or_url(uri, *, keep_local=True, force_signed=False):
         return uri      # no storage wrapper
 
     if info.scheme=='s3':
-        return _storage_s3(bucket=info.netloc, keep_local=keep_local, force_signed=force_signed)(uri)
+        try:
+            return _storage_s3(bucket=info.netloc, keep_local=keep_local, retries=retries)(uri)
+        except RemoteFilesMissingCredentials as e:
+            raise Exception(f"AWS credentials are required to access {uri!r}") from e
 
     if info.scheme in ['http', 'https']:
-        return _storage_http(keep_local=keep_local)(uri)
+        return _storage_http(keep_local=keep_local, retries=retries)(uri)
 
     if info.scheme in ['gs', 'gcs']:
-        return _storage_gcs(keep_local=keep_local)(uri)
+        return _storage_gcs(keep_local=keep_local, retries=retries)(uri)
 
     raise Exception(f"Input address {uri!r} (scheme={info.scheme!r}) is from a non-supported remote")

--- a/phylogenetic/rules/remote_files.smk
+++ b/phylogenetic/rules/remote_files.smk
@@ -131,8 +131,11 @@ def path_or_url(uri, *, keep_local=True, retries=2) -> str:
         except RemoteFilesMissingCredentials as e:
             raise Exception(f"AWS credentials are required to access {uri!r}") from e
 
-    if info.scheme in ['http', 'https']:
+    if info.scheme=='https':
         return _storage_http(keep_local=keep_local, retries=retries)(uri)
+    elif info.scheme=='http':
+        raise Exception(f"HTTP remote file support is not implemented in nextstrain workflows (attempting to access {uri!r}).\n"
+            "Please use an HTTPS address instead.")
 
     if info.scheme in ['gs', 'gcs']:
         raise Exception(f"Google Storage is not yet implemented for nextstrain workflows (attempting to access {uri!r}).\n"


### PR DESCRIPTION
Initial work to support remote files (S3, HTTP) using Snakemake storage support. The intention is for:
* This to be merged into #80 which will then be blocked on runtime snakemake v8+ (i.e. v9) support
* Eventually this code will make it into `shared/` and end up in many repos

All contributions, testing etc welcome. Please feel free to add commits directly to this PR. We should probably add Google Storage, since it's in ncov?

## Dependencies needed:
* snakemake-storage-plugin-s3
* snakemake-storage-plugin-http
* ? Google storage plugin

```
conda install -c conda-forge -c bioconda snakemake-storage-plugin-s3 snakemake-storage-plugin-http
```

## Where's data stored?

Within `.snakemake/storage/<tag-name>/`. This is a nicer solution than the current ncov version which stores files in top-level directories which require git-ignoring. Here's the canonical curated data from our S3 bucket:

```console
$ tree .snakemake/storage
.snakemake/storage
├── s3
└── s3_unsigned
    └── nextstrain-data
        └── files
            └── workflows
                └── zika
                    ├── metadata.tsv.zst
                    └── sequences.fasta.zst
```

## Goodbye `./data`?

Since the fetched data is stored within `.snakemake` (see above), our workflows won't use `./data` directories any more. (Zika currently uses it for USVI data, but we'll change that as part of this PR or the parent PR.)

## External analysis directories

These work out of the box which is nice! The files are stored within the analysis directories `.snakemake` folder, as expected. 

> To test these you mustn't use the local-to-pathogen-repo USVI data (see parent PR for details)

## S3
I've set up S3 to use different storage providers depending on if we think credentials are needed or not, which mirrors our previous `aws s3 cp --no-sign-request` approach. 

### Missing credentials can be confusing

If credentials are required (an easy way to test this is to set `PUBLIC_BUCKETS` to an empty set so that we attempt to use credentials for the canonical nextstrain-data) then depending on how we invoke snakemake we get different errors. I believe this is due to if the inputs of the target rule are fetched from remote storage, or if they TKTK


**Case 1:** The target rule doesn't itself use a remote storage file, but somewhere in the DAG we do fetch files from S3. E.g. define multiple inputs such that we fetch one set of data from S3 and another set from local USVI data. The behaviour here is what I would expect:

```console
$ snakemake --cores 1 -pf results/filtered.fasta # no AWS credentials in env
...
WorkflowError:
Failed to check existence of s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst
NoCredentialsError: Unable to locate credentials
```

```console
$ envdir ... snakemake --cores 1 -pf results/filtered.fasta # AWS credentials provided
...
Retrieving from storage: s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst
Finished retrieval.
Retrieving from storage: s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst
Finished retrieval.
...
[Mon Jul  7 15:09:24 2025]
localrule merge_metadata:
    input: s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst (retrieve from storage), data/metadata_usvi.tsv
```

**Case 2:** The target rule uses `path_or_url` directly as an input. For instance, we run the `merge_metadata` rule from the default config which sources a file directly from S3.

Without credentials we get a very confusing `Missing input files` error:

```console
$ snakemake --cores 1 -npf results/metadata_merged.tsv # no AWS credentials in env
...
MissingInputException in rule merge_metadata in file "/Users/naboo/github/nextstrain/zika/phylogenetic/rules/merge_inputs.smk", line 56:
Missing input files for rule merge_metadata:
    output: results/metadata_merged.tsv
    affected files:
        .snakemake/storage/s3_signed/nextstrain-data/files/workflows/zika/metadata.tsv.zst
```

If you have credentials then this works as expected (see case 1 above)

I presume the same confusion occurs with credentials which don't grant authz, but I have't checked.
My hunch is that this behaviour happens because we aren't directly using `storage.<tag>` wrappers in inputs/outputs of rules, but I haven't done much digging.


### Is data re-fetched as needed?
We use `keep_local=True` so that we keep the downloaded files and thus don't have to re-fetch them upon each snakemake invocation. The presence of a [mtime method in the S3 plugin](https://github.com/snakemake/snakemake-storage-plugin-s3/blob/main/snakemake_storage_plugin_s3/__init__.py#L293-L298) implies that a cache check is made. This would mirror the behaviour in our ncov implementation. We should document how we can avoid this, because it can trigger a workflow re-run when not desired (common for dev work).

**More credential strangeness** There's some subtlety I don't fully understand here. E.g.: if you have successfully completed a credentialed fetch of the files (e.g. S3 sequences & metadata), and thus they're stored on disk at `.snakemake/storage/s3_signed`, and then we run another invocation _without_ credentials:

* Case 1 above - `snakemake --cores 1 -pf results/filtered.fasta # no AWS credentials in env` - works just fine, i.e. the `rule filter` runs successfully.
* Case 2 above - `snakemake --cores 1 -npf results/metadata_merged.tsv # no AWS credentials in env` - we get the same `Missing input files` error. 


### Uploading data

I don't know if we used this in ncov, but it could be helpful. Tested using the following rule:

```python
rule upload_filter:
    """TESTING ONLY TODO XXX REMOVE"""
    input: "results/filtered.fasta"
    output: path_or_url("s3://nextstrain-scratch/testing-zika-filtered.fasta")
    shell:
        r"""
        cp {input[0]} {output[0]}
        """
```

```console
$ envdir ... snakemake --cores 1 -pf upload_filter # AWS credentials needed 
[Mon Jul  7 16:05:13 2025]
localrule upload_filter:
    input: results/filtered.fasta
    output: s3://nextstrain-scratch/testing-zika-filtered.fasta (send to storage)
    jobid: 0
    reason: Forced execution
    resources: tmpdir=/var/folders/j5/0z9xm99d1pz9nqlpgg9c6xqr0000gn/T
Shell command: 
        cp results/filtered.fasta .snakemake/storage/s3_signed/nextstrain-scratch/testing-zika-filtered.fasta
        
Storing in storage: s3://nextstrain-scratch/testing-zika-filtered.fasta
```

This is the reason for the `force_signed` keyword argument, as uploading to (e.g.) `nextstrain-data` needs credentials but downloading doesn't. 


## HTTP[S]

Running with a single set of inputs from data.nextstrain.org (and no additional inputs) worked:

```yaml
# config.yaml
inputs:
  - name: ncbi
    metadata: "https://data.nextstrain.org/files/workflows/zika/metadata.tsv.zst"
    sequences: "https://data.nextstrain.org/files/workflows/zika/sequences.fasta.zst"
```

~However using raw.githubusercontent.com URLs didn't work (`curl`ing them was fine):~ _This was a typo - now fixed in this PR._

### Uploading data

Didn't test! Seems possible via a POST, but ???

## Google Storage

Todo?


## File Compression

_This isn't really about snakemake storage solutions at all, but might as well sort it out here_

From some basic testing:
* Metadata:
    * If there are multiple metadata inputs, then they can be zst compressed and `augur merge` does the right thing.
    * If there's only one input then `augur filter` does the right thing (for zst)
* Sequences:
    * Multiple sequences go through seqkit (soon to be augur merge?) which does the right thing for zst
    * One sequence input: `augur filter` does the right thing  for zst

So assuming we switch from `seqkit` to `augur merge` for sequences (which will use... `seqkit`) then I think we support compression of remote files _if_ `augur filter` and `augur merge` support it.


## Relevant docs pages
https://snakemake.readthedocs.io/en/stable/snakefiles/storage.html
https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/http.html
https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/s3.html
https://github.com/snakemake/snakemake-storage-plugin-s3/blob/main/snakemake_storage_plugin_s3/__init__.py
https://github.com/snakemake/snakemake-storage-plugin-http/blob/main/snakemake_storage_plugin_http/__init__.py


