### PR TITLE
phylo/merge_inputs: Use standard rules

### DIFF
--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -3,7 +3,7 @@ This part of the workflow creates additonal annotations for the phylogenetic tre
 
 REQUIRED INPUTS:
 
-    metadata            = [from input_metadata function]
+    metadata            = results/metadata.tsv
     prepared_sequences  = results/aligned.fasta
     tree                = results/tree.nwk
 
@@ -103,7 +103,7 @@ rule traits:
     """
     input:
         tree = "results/tree.nwk",
-        metadata = input_metadata,
+        metadata = "results/metadata.tsv",
     output:
         node_data = "results/traits.json",
     params:

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -3,7 +3,7 @@ This part of the workflow constructs the phylogenetic tree.
 
 REQUIRED INPUTS:
 
-    metadata            = [from input_metadata function]
+    metadata            = results/metadata.tsv
     prepared_sequences  = results/aligned.fasta
 
 OUTPUTS:
@@ -51,7 +51,7 @@ rule refine:
     input:
         tree = "results/tree_raw.nwk",
         alignment = "results/aligned.fasta",
-        metadata = input_metadata,
+        metadata = "results/metadata.tsv",
     output:
         tree = "results/tree.nwk",
         node_data = "results/branch_lengths.json"

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -4,7 +4,7 @@ export a Nextstrain dataset.
 
 REQUIRED INPUTS:
 
-    metadata        = [from input_metadata function]
+    metadata        = results/metadata.tsv
     tree            = results/tree.nwk
     branch_lengths  = results/branch_lengths.json
     node_data       = results/*.json
@@ -29,7 +29,7 @@ rule export:
     """Exporting data files for for auspice"""
     input:
         tree = "results/tree.nwk",
-        metadata = input_metadata,
+        metadata = "results/metadata.tsv",
         branch_lengths = "results/branch_lengths.json",
         traits = "results/traits.json",
         nt_muts = "results/nt_muts.json",

--- a/phylogenetic/rules/merge_inputs.smk
+++ b/phylogenetic/rules/merge_inputs.smk
@@ -1,26 +1,33 @@
 """
-This part of the workflow merges inputs from any of:
-    curated NCBI dataset: via s3 remote
-    additional local data: via path to files
-
-based on what is defined in the config YAML file.
-
-REQUIRED INPUTS:
-
-    config.yaml  = defines input files within a dictionary in either 'inputs' or 'additional_inputs'
+This part of the workflow merges inputs based on what is defined in the config.
 
 OUTPUTS:
 
-    input_sequences = gathered and merged sequences
-    input_metadata  = gathered and merged metadata
+    metadata  = results/metadata.tsv
+    sequences = results/sequences.fasta
 
+The config dict is expected to have a top-level `inputs` list that defines the
+separate inputs' name, metadata, and sequences. Optionally, the config can have
+a top-level `additional-inputs` list that is used to define additional data that
+are combined with the default inputs:
 
-This part of the workflow usually includes the following steps:
+```yaml
+inputs:
+    - name: default
+      metadata: <path-or-url>
+      sequences: <path-or-url>
 
-    - Any transformation to match the columns of the tsv files
-    - Concatenation of the tsv and the sequences files
+additional_inputs:
+    - name: private
+      metadata: <path-or-url>
+      sequences: <path-or-url>
+```
 
+Supports any of the compression formats that are supported by `augur read-file`,
+see <https://docs.nextstrain.org/projects/augur/page/usage/cli/read-file.html>
 """
+from pathlib import Path
+
 
 def _gather_inputs():
     all_inputs = [*config['inputs'], *config.get('additional_inputs', [])]
@@ -28,12 +35,16 @@ def _gather_inputs():
     if len(all_inputs)==0:
         raise InvalidConfigError("Config must define at least one element in config.inputs or config.additional_inputs lists")
     if not all([isinstance(i, dict) for i in all_inputs]):
-        raise InvalidConfigError("All of the elements in config.inputs and config.additional_inputs lists must be dictionaries"
+        raise InvalidConfigError("All of the elements in config.inputs and config.additional_inputs lists must be dictionaries. "
             "If you've used a command line '--config' double check your quoting.")
     if len({i['name'] for i in all_inputs})!=len(all_inputs):
         raise InvalidConfigError("Names of inputs (config.inputs and config.additional_inputs) must be unique")
     if not all(['name' in i and ('sequences' in i or 'metadata' in i) for i in all_inputs]):
         raise InvalidConfigError("Each input (config.inputs and config.additional_inputs) must have a 'name' and 'metadata' and/or 'sequences'")
+    if not any(['metadata' in i for i in all_inputs]):
+        raise InvalidConfigError("At least one input must have 'metadata'")
+    if not any (['sequences' in i for i in all_inputs]):
+        raise InvalidConfigError("At least one input must have 'sequences'")
 
     available_keys = set(['name', 'metadata', 'sequences'])
     if any([len(set(el.keys())-available_keys)>0 for el in all_inputs]):
@@ -42,61 +53,105 @@ def _gather_inputs():
     return {el['name']: {k:(v if k=='name' else path_or_url(v)) for k,v in el.items()} for el in all_inputs}
 
 input_sources = _gather_inputs()
+_input_metadata = [info['metadata'] for info in input_sources.values() if info.get('metadata', None)]
+_input_sequences = [info['sequences'] for info in input_sources.values() if info.get('sequences', None)]
 
-def input_metadata(wildcards):
-    inputs = [info['metadata'] for info in input_sources.values() if info.get('metadata', None)]
-    return inputs[0] if len(inputs)==1 else "results/metadata_merged.tsv"
 
-def input_sequences(wildcards):
-    inputs = [info['sequences'] for info in input_sources.values() if info.get('sequences', None)]
-    return inputs[0] if len(inputs)==1 else "results/sequences_merged.fasta"
+if len(_input_metadata) == 1:
 
-rule merge_metadata:
-    """
-    This rule should only be invoked if there are multiple defined metadata inputs
-    (config.inputs + config.additional_inputs)
-    """
-    input:
-        **{name: info['metadata'] for name,info in input_sources.items() if info.get('metadata', None)}
-    params:
-        metadata = lambda w, input: list(map("=".join, input.items())),
-        id_field = config['strain_id_field'],
-    output:
-        metadata = "results/metadata_merged.tsv"
-    log:
-        "logs/merge_metadata.txt",
-    benchmark:
-        "benchmarks/merge_metadata.txt"
-    shell:
-        r"""
-        exec &> >(tee {log:q})
-
-        augur merge \
-            --metadata {params.metadata:q} \
-            --metadata-id-columns {params.id_field:q} \
-            --output-metadata {output.metadata:q}
+    rule decompress_metadata:
         """
-
-rule merge_sequences:
-    """
-    This rule should only be invoked if there are multiple defined sequences inputs
-    (config.inputs + config.additional_inputs) for this particular segment
-    """
-    input:
-        **{name: info['sequences'] for name,info in input_sources.items() if info.get('sequences', None)}
-    output:
-        sequences = "results/sequences_merged.fasta"
-    log:
-        "logs/merge_sequences.txt",
-    benchmark:
-        "benchmarks/merge_sequences.txt"
-    shell:
-        r"""
-        exec &> >(tee {log:q})
-
-        augur merge \
-            --sequences {input:q} \
-            --output-sequences {output.sequences:q}
+        This rule is invoked when there is a single metadata input to
+        ensure that we have a decompressed input for downstream rules to match
+        the output of rule.merge_metadata.
         """
+        input:
+            metadata = _input_metadata[0],
+        output:
+            metadata = "results/metadata.tsv",
+        log:
+            "logs/decompress_metadata.txt",
+        benchmark:
+            "benchmarks/decompress_metadata.txt",
+        shell:
+            r"""
+            exec &> >(tee {log:q})
 
-# -------------------------------------------------------------------------------------------- #
+            augur read-file {input.metadata:q} > {output.metadata:q}
+            """
+
+else:
+
+    rule merge_metadata:
+        """
+        This rule is invoked when there are multiple defined metadata inputs
+        (config.inputs + config.additional_inputs)
+        """
+        input:
+            **{name: info['metadata'] for name,info in input_sources.items() if info.get('metadata', None)}
+        params:
+            metadata = lambda w, input: list(map("=".join, input.items())),
+            id_field = config['strain_id_field'],
+        output:
+            metadata = "results/metadata.tsv"
+        log:
+            "logs/merge_metadata.txt",
+        benchmark:
+            "benchmarks/merge_metadata.txt"
+        shell:
+            r"""
+            exec &> >(tee {log:q})
+
+            augur merge \
+                --metadata {params.metadata:q} \
+                --metadata-id-columns {params.id_field:q} \
+                --output-metadata {output.metadata:q}
+            """
+
+
+if len(_input_sequences) == 1:
+
+    rule decompress_sequences:
+        """
+        This rule is invoked when there is a single sequences input to
+        ensure that we have a decompressed input for downstream rules to match
+        the output of rule.merge_sequences.
+        """
+        input:
+            sequences = _input_sequences[0],
+        output:
+            sequences = "results/sequences.fasta",
+        log:
+            "logs/decompress_sequences.txt",
+        benchmark:
+            "benchmarks/decompress_sequences.txt",
+        shell:
+            r"""
+            exec &> >(tee {log:q})
+
+            augur read-file {input.sequences:q} > {output.sequences:q}
+            """
+
+else:
+
+    rule merge_sequences:
+        """
+        This rule is invoked when there are multiple defined sequences inputs
+        (config.inputs + config.additional_inputs)
+        """
+        input:
+            **{name: info['sequences'] for name,info in input_sources.items() if info.get('sequences', None)}
+        output:
+            sequences = "results/sequences.fasta",
+        log:
+            "logs/merge_sequences.txt",
+        benchmark:
+            "benchmarks/merge_sequences.txt"
+        shell:
+            r"""
+            exec &> >(tee {log:q})
+
+            augur merge \
+                --sequences {input:q} \
+                --output-sequences {output.sequences:q}
+            """

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -3,8 +3,8 @@ This part of the workflow prepares sequences for constructing the phylogenetic t
 
 REQUIRED INPUTS:
 
-    metadata_url    = url to metadata.tsv.zst
-    sequences_url   = url to sequences.fasta.zst
+    metadata_url    = results/metadata.tsv
+    sequences_url   = results/sequences.fasta
     reference   = path to reference sequence or genbank
 
 OUTPUTS:
@@ -30,8 +30,8 @@ rule filter:
       - minimum genome length of {params.min_length} (50% of Zika virus genome)
     """
     input:
-        sequences = input_sequences,
-        metadata = input_metadata,
+        sequences = "results/sequences.fasta",
+        metadata = "results/metadata.tsv",
         exclude = resolve_config_path(config["exclude"]),
     output:
         sequences = "results/filtered.fasta"


### PR DESCRIPTION
## Description of proposed changes

Use the standard rules added to pathogen-repo-guide in  https://github.com/nextstrain/pathogen-repo-guide/pull/91.

The config parameters remain unchanged so this should not affect outside users.  Downstream rules are now expected to use "results/metadata.tsv" and  "results/sequences.fasta" as inputs instead of the `input_*` functions.

## Related issue(s)

https://github.com/nextstrain/public/issues/25

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
